### PR TITLE
Always allow accents and case in the input

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -136,15 +136,7 @@ export default class Async extends Component {
 	}
 
 	_onInputChange (inputValue) {
-		const { ignoreAccents, ignoreCase, onInputChange } = this.props;
-
-		if (ignoreAccents) {
-			inputValue = stripDiacritics(inputValue);
-		}
-
-		if (ignoreCase) {
-			inputValue = inputValue.toLowerCase();
-		}
+		const { onInputChange } = this.props;
 
 		if (onInputChange) {
 			onInputChange(inputValue);


### PR DESCRIPTION
It would be nice to always allow accents and case in the Input regardless of if `ignoreAccents` or `ignoreCase` are true, especially when using create mode (since you may want to create a value that has accents or is case-sensitive).

For filtering purposes these changes are still applied to the input value in `defaultFilterOptions.js`.

I tested this on our setup which is running release 1.0.0-rc.5